### PR TITLE
[FIX] "unbound variable $mdi-css-prefix"

### DIFF
--- a/scss/_core.scss
+++ b/scss/_core.scss
@@ -1,3 +1,4 @@
+@import "variables";
 .#{$mdi-css-prefix} {
   display: inline-block;
   font: normal normal normal #{$mdi-font-size-base}/1 MaterialDesignIcons; // shortening font declaration


### PR DESCRIPTION
Prevents from getting the following error message during compilation of scss files:
```
Sass error: { status: 1,
  file: '/home/max/WebstormProjects/layout_tango-bielefeld.de/bower_components/mdi/scss/_core.scss',
  line: 2,
  column: 1,
  message: 'unbound variable $mdi-css-prefix',
  code: 1 }
```