### PR TITLE
Renamed global SASS variables in extras

### DIFF
--- a/scss/_extras.scss
+++ b/scss/_extras.scss
@@ -1,9 +1,9 @@
-$sizes: 18 24 36 48;
-@each $size in $sizes {
-    .#{$mdi-css-prefix}-#{$size}px {
+$mdi-sizes: 18 24 36 48;
+@each $mdi-size in $mdi-sizes {
+    .#{$mdi-css-prefix}-#{$mdi-size}px {
         &.#{$mdi-css-prefix}-set,
         &.#{$mdi-css-prefix}:before {
-            font-size: $size * 1px;
+            font-size: $mdi-size * 1px;
         }
     }
 }
@@ -25,26 +25,26 @@ $sizes: 18 24 36 48;
     }
 }
 
-$degrees: 45 90 135 180 225 270 315;
-@each $degree in $degrees {
-    .#{$mdi-css-prefix}-rotate-#{$degree}{
+$mdi-degrees: 45 90 135 180 225 270 315;
+@each $mdi-degree in $mdi-degrees {
+    .#{$mdi-css-prefix}-rotate-#{$mdi-degree}{
         &:before {
-            -webkit-transform: rotate(#{$degree}deg);
-            -ms-transform: rotate(#{$degree}deg);
-            transform: rotate(#{$degree}deg);
+            -webkit-transform: rotate(#{$mdi-degree}deg);
+            -ms-transform: rotate(#{$mdi-degree}deg);
+            transform: rotate(#{$mdi-degree}deg);
         }
         /*
         // Not included in production
         &.#{$mdi-css-prefix}-flip-h:before {
-            -webkit-transform: scaleX(-1) rotate(#{$degree}deg);
-            transform: scaleX(-1) rotate(#{$degree}deg);
+            -webkit-transform: scaleX(-1) rotate(#{$mdi-degree}deg);
+            transform: scaleX(-1) rotate(#{$mdi-degree}deg);
             filter: FlipH;
             -ms-filter: "FlipH";
         }
         &.#{$mdi-css-prefix}-flip-v:before {
-            -webkit-transform: scaleY(-1) rotate(#{$degree}deg);
-            -ms-transform: rotate(#{$degree}deg);
-            transform: scaleY(-1) rotate(#{$degree}deg);
+            -webkit-transform: scaleY(-1) rotate(#{$mdi-degree}deg);
+            -ms-transform: rotate(#{$mdi-degree}deg);
+            transform: scaleY(-1) rotate(#{$mdi-degree}deg);
             filter: FlipV;
             -ms-filter: "FlipV";
         }


### PR DESCRIPTION
I renamed the global variables (`$sizes` and `$degrees`) in `_extras.scss` to be more specific and avoid conflicts with other libraries/frameworks (for example Bootstrap 4).