### PR TITLE
Fix "Multiple assets emit..." for webpack@4.40.x

### DIFF
--- a/scss/_path.scss
+++ b/scss/_path.scss
@@ -1,6 +1,5 @@
 @font-face {
   font-family: '#{$mdi-font-name}';
-  src: url('#{$mdi-font-path}/#{$mdi-filename}-webfont.eot?v=#{$mdi-version}');
   src: url('#{$mdi-font-path}/#{$mdi-filename}-webfont.eot?#iefix&v=#{$mdi-version}') format('embedded-opentype'),
     url('#{$mdi-font-path}/#{$mdi-filename}-webfont.woff2?v=#{$mdi-version}') format('woff2'),
     url('#{$mdi-font-path}/#{$mdi-filename}-webfont.woff?v=#{$mdi-version}') format('woff'),


### PR DESCRIPTION
The latest webpack update broke the `@mdi/font package` in build time.
Webpack devops added check for duplicate depending assets and throws error:
`Conflict: Multiple assets emit to the same filename 1993c4a16cce5446a5cfafacf4da740b.eot`