### PR TITLE
Adds local source for fonts

### DIFF
--- a/scss/_path.scss
+++ b/scss/_path.scss
@@ -1,5 +1,6 @@
 @font-face {
   font-family: '#{$mdi-font-name}';
+  src: local('Material Design Icons');
   src: url('#{$mdi-font-path}/#{$mdi-filename}-webfont.eot?v=#{$mdi-version}');
   src: url('#{$mdi-font-path}/#{$mdi-filename}-webfont.eot?#iefix&v=#{$mdi-version}') format('embedded-opentype'),
     url('#{$mdi-font-path}/#{$mdi-filename}-webfont.woff2?v=#{$mdi-version}') format('woff2'),


### PR DESCRIPTION
Adds local source for fonts to allow for installing the fonts on a machine and still be able to access without downloading. This is helpful in situations where a security policy prohibits downloading fonts. Installing is typically used in this case as a workaround but requires a css change to be used.