### PR TITLE
Fix license field in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,16 +20,7 @@
     "name": "Austin Andrews",
     "web": "http://twitter.com/templarian"
   },
-  "licenses": [
-    {
-      "type": "OFL-1.1",
-      "url": "http://scripts.sil.org/OFL"
-    },
-    {
-      "type": "MIT",
-      "url": "http://opensource.org/licenses/mit-license.html"
-    }
-  ],
+  "license": "(OFL-1.1 AND MIT)",
   "bugs": {
     "url": "https://github.com/Templarian/MaterialDesign/issues"
   },


### PR DESCRIPTION
The licenses field in package.json is deprecated. Instead the license field with an SPDX license expression should be used to display the licenses correctly on npm.
See https://docs.npmjs.com/files/package.json#license