### PR TITLE
add missing clock alias

### DIFF
--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -5639,6 +5639,7 @@ $mdi-icons: (
   "scatter-plot-outline": F0ECA,
   "scent": F1958,
   "scent-off": F1959,
+  "schedule": F0B57,
   "school": F0474,
   "school-outline": F1180,
   "scissors-cutting": F0A6B,


### PR DESCRIPTION
According to the docs, the `clock-outline` icon should have the alias `schedule` but it's not present.