### PR TITLE
Make mdi-version optional.

### DIFF
--- a/scss/_path.scss
+++ b/scss/_path.scss
@@ -1,10 +1,18 @@
 @font-face {
+  @function mdi-version-string($v, $c) {
+    $version-string: "";
+    @if $v and $v != "0" {
+      $version-string: "#{$c}#{$v}";
+    }
+    @return $version-string;
+  }
+
   font-family: '#{$mdi-font-name}';
-  src: url('#{$mdi-font-path}/#{$mdi-filename}-webfont.eot?v=#{$mdi-version}');
-  src: url('#{$mdi-font-path}/#{$mdi-filename}-webfont.eot?#iefix&v=#{$mdi-version}') format('embedded-opentype'),
-    url('#{$mdi-font-path}/#{$mdi-filename}-webfont.woff2?v=#{$mdi-version}') format('woff2'),
-    url('#{$mdi-font-path}/#{$mdi-filename}-webfont.woff?v=#{$mdi-version}') format('woff'),
-    url('#{$mdi-font-path}/#{$mdi-filename}-webfont.ttf?v=#{$mdi-version}') format('truetype');
+  src: url('#{$mdi-font-path}/#{$mdi-filename}-webfont.eot#{mdi-version-string($mdi-version, "?v")}');
+  src: url('#{$mdi-font-path}/#{$mdi-filename}-webfont.eot?#iefix#{mdi-version-string($mdi-version, "&v=")}') format('embedded-opentype'),
+    url('#{$mdi-font-path}/#{$mdi-filename}-webfont.woff2#{mdi-version-string($mdi-version, "?v")}') format('woff2'),
+    url('#{$mdi-font-path}/#{$mdi-filename}-webfont.woff#{mdi-version-string($mdi-version, "?v")}') format('woff'),
+    url('#{$mdi-font-path}/#{$mdi-filename}-webfont.ttf#{mdi-version-string($mdi-version, "?v")}') format('truetype');
   font-weight: normal;
   font-style: normal;
 }


### PR DESCRIPTION
Adding the version query param in `scss/_path.scss` resulting in urls like `...materialdesignicons-webfont.woff2?v=7.3.67` break caching in some contexts because the cached asset name doesn't include the query string. One case is auto generated precaching in service workers. This commit allows you to override the `$mdi-version` variable with `0` or unset it to have the query parameter omitted from the URLs.